### PR TITLE
Whitelist Support

### DIFF
--- a/functions/fnc_addSettings.sqf
+++ b/functions/fnc_addSettings.sqf
@@ -58,7 +58,35 @@ private _componentBeautified = QUOTE(COMPONENT_BEAUTIFIED);
 	_componentBeautified, //Category
 	str _arr, //Setting properties. Varies based on type
 	1, //1: all clients share the same setting, 2: setting can’t be overwritten
-	{}, //Code to execute upon setting change
+	{ //Code to execute upon setting change
+		private _newBlacklistArray = parseSimpleArray _this;
+		private _blacklistMap = createHashMap;
+		_newBlacklistArray apply {
+			_blacklistMap set [toLowerANSI _x,true];
+		};
+		EGVAR(blacklistedClasses,map) = _blacklistMap;
+	},
+	false //Requires restart?
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(whitelistedClasses), //Setting classname
+	"EDITBOX", //Setting type. Can be CHECKBOX, LIST, SLIDER, COLOR, EDITBOX, TIME
+	[
+		"Whitelisted Classes", //Display name
+		"Primaries will be able to be equipped as second primaries if they are in this array. Array of string classnames. If empty, all weapons not blacklisted will be allowed" //Tooltip
+	],
+	_componentBeautified, //Category
+	str _arr, //Setting properties. Varies based on type
+	1, //1: all clients share the same setting, 2: setting can’t be overwritten
+	{ //Code to execute upon setting change
+		private _newWhitelistArray = parseSimpleArray _this;
+		private _whitelistMap = createHashMap;
+		_newWhitelistArray apply {
+			_whitelistMap set [toLowerANSI _x,true];
+		};
+		EGVAR(whitelistedClasses,map) = _whitelistMap;
+	},
 	false //Requires restart?
 ] call CBA_fnc_addSetting;
 

--- a/functions/fnc_switchPrimaryHandler.sqf
+++ b/functions/fnc_switchPrimaryHandler.sqf
@@ -16,7 +16,6 @@
  *  Public: Yes
  */
 
-// "arifle_MX_SW_pointer_F"
 params ["_delay"];
 
 private _weapon = primaryWeapon player;

--- a/functions/fnc_switchPrimaryHandler.sqf
+++ b/functions/fnc_switchPrimaryHandler.sqf
@@ -16,11 +16,24 @@
  *  Public: Yes
  */
 
-
+// "arifle_MX_SW_pointer_F"
 params ["_delay"];
 
 private _weapon = primaryWeapon player;
-if ((!(GVAR(Enabled))) || {_weapon in parseSimpleArray (GVAR(blacklistedClasses))}) exitWith {};
+private _systemEnabled = GVAR(Enabled);
+private _weaponIsValid = true;
+if (_systemEnabled && (_weapon isNotEqualTo "")) then {
+	private _weaponLowered = toLowerANSI _weapon;
+	private _whitelist = EGVAR(whitelistedClasses,map);
+	private _whitelistHasValues = (count _whitelist) > 0;
+
+	private _matchesWhitelist = (!_whitelistHasValues) || (_weaponLowered in _whitelist);
+	private _matchesBlacklist = _weaponLowered in (EGVAR(blacklistedClasses,map));
+
+	_weaponIsValid = (!_matchesBlacklist) && _matchesWhitelist;
+};
+
+if ((!_systemEnabled) || (!_weaponIsValid)) exitWith {};
 
 private _secondPrimaryEquipped = player getVariable [QGVAR(secondPrimaryEquipped),false];
 if (_secondPrimaryEquipped) then {


### PR DESCRIPTION
Changes:
- Adds a companion setting to the blacklist that will whitelist classnames. Blacklist and whitelist work in conjunction with the blacklist superseding the whitelist if a value is in both.
- White and black lists will be converted to a hashmap (that is effectively used as a Set) for consistent lookup times no matter the size of the list.
- Moved the parsing of the setting string to only happen when the setting changes/initializes.
- Made the black and white lists case insensitive.